### PR TITLE
Fix local compiler on windows

### DIFF
--- a/src/components/Debugger.js
+++ b/src/components/Debugger.js
@@ -1114,7 +1114,7 @@ void loop() {
 	let sketchExp;
 
 	if( lsp ){
-	    sketchExp = new RegExp( this.escapeRegex(lbp) + path.sep + "sketch" + path.sep + "(.*)" );
+	    sketchExp = new RegExp( this.escapeRegex(lbp) + this.escapeRegex(path.sep) + "sketch" + this.escapeRegex(path.sep) + "(.*)" );
 	}else
 	    sketchExp = /^\/app\/public\/builds\/[0-9]+\/sketch\/(.*)/;
 	


### PR DESCRIPTION
Escape the path separator in the regex correctly to avoid escaping other characters. This should fix issue #47.