### PR TITLE
Correct game name

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can start/stop recording a GIF of the game by pressing <kbd>**R**</kbd>. If 
 
 To exit a game and go back to the list, press <kbd>**Esc**</kbd> or click on the **power button** above the screen.
 
-Some games look/play better on a vertical screen, like [1942](https://felipemanga.github.io/ProjectABE/?url=https://raw.githubusercontent.com/eried/ArduboyCollection/master/Arcade%2F1943%2F1943.hex) or [Breakout-V](https://felipemanga.github.io/ProjectABE/?url=http://www.crait.net/arduboy/breakoutv/app.hex). The emulator can be put in vertical mode by clicking on the **chip in the lower-right** of the Arduboy's screen.
+Some games look/play better on a vertical screen, like [1943](https://felipemanga.github.io/ProjectABE/?url=https://raw.githubusercontent.com/eried/ArduboyCollection/master/Arcade%2F1943%2F1943.hex) or [Breakout-V](https://felipemanga.github.io/ProjectABE/?url=http://www.crait.net/arduboy/breakoutv/app.hex). The emulator can be put in vertical mode by clicking on the **chip in the lower-right** of the Arduboy's screen.
 
 Aside from the standard Arduboy and Microcard, other skins are available. Press <kbd>**F3**</kbd> to cycle through them. You can specify which skin to load by adding a parameter to the URL (`?hex=game.hex&skin=Tama`) or the commandline (`ProjectABE --skin=Tama game.hex`).
 


### PR DESCRIPTION
Should be '[1943](https://en.wikipedia.org/wiki/1943:_The_Battle_of_Midway)' instead of '[1942](https://en.wikipedia.org/wiki/1942_(video_game))'.